### PR TITLE
Linux build supporting older versions of GLIBC

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,4 +25,12 @@ jobs:
     
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build --release --target x86_64-unknown-linux-musl
+      run: |
+        cd rust-proxy
+        cargo build --release --target x86_64-unknown-linux-musl
+    
+    - uses: actions/upload-artifact@v3
+      with:
+        name: my-artifact
+        path: |
+          rust-proxy/target/x86_64-unknown-linux-musl/**/g-cli

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,28 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux2014_x86_64
+
+    steps:
+    
+    - name: Install Rust Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: x86_64-unknown-linux-musl
+    
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --release --target x86_64-unknown-linux-musl

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,6 @@ jobs:
     
     - uses: actions/upload-artifact@v3
       with:
-        name: my-artifact
+        name: g-cli linux binary
         path: |
           rust-proxy/target/x86_64-unknown-linux-musl/**/g-cli


### PR DESCRIPTION
See here for some background:
https://kobzol.github.io/rust/ci/2021/05/07/building-rust-binaries-in-ci-that-work-with-older-glibc.html